### PR TITLE
[FEATURE] Add allowedRefsPattern config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ See https://github.com/dflydev/dflydev-git-subsplit-github-webhook#configuration
 `allowed-ips` is not supported, since slicer is intended to be run in Jenkins and that has ways to secure the
 request.
 
+One addition is the `allowedRefsPattern` that can be given per project. If it does not match an incoming `ref`
+in the payload, processing of the split is skipped.
+
 ## Setting up Jenkins
 
 * Create parameterized job

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "projects": {
     "Flow": {
       "url": "https://github.com/neos/flow-development-collection",
+      "allowedRefsPattern": "/^refs\/(tags|heads)\/(FLOW3-)?[0-9]+\\.[0-9]+(\\.[0-9]+)?$/",
       "splits": [
         "TYPO3.Eel:git@github.com:neos/eel.git",
         "TYPO3.Flow:git@github.com:neos/flow.git",
@@ -12,6 +13,7 @@
     },
     "Neos": {
       "url": "https://github.com/neos/neos-development-collection",
+      "allowedRefsPattern": "/^refs\/(tags|heads)\/[0-9]+\\.[0-9]+(\\.[0-9]+)?$/",
       "splits": [
         "TYPO3.Media:git@github.com:neos/media.git",
         "TYPO3.Neos:git@github.com:neos/neos.git",

--- a/slicer.php
+++ b/slicer.php
@@ -29,12 +29,17 @@ if ($name === NULL) {
 	exit(1);
 }
 
+$ref = $data['ref'];
+if (isset($project['allowedRefsPattern']) && preg_match($project['allowedRefsPattern'], $ref) !== 1) {
+	echo sprintf('Skipping request (blacklisted reference detected: %s)', $ref) . PHP_EOL;
+	exit(0);
+}
+
 $publishCommand = [sprintf('%s publish --update %s',
 	$gitSubsplitBinary,
 	escapeshellarg(implode(' ', $project['splits']))
 )];
 
-$ref = $data['ref'];
 if (preg_match('/refs\/tags\/(.+)$/', $ref, $matches)) {
 	$publishCommand[] = escapeshellarg('--no-heads');
 	$publishCommand[] = escapeshellarg(sprintf('--tags=%s', $matches[1]));


### PR DESCRIPTION
The `allowedRefsPattern` can be given per project in `config.json`. If
it is given and does not match an incoming `ref` in the payload,
processing of the split is skipped.