### PR TITLE
TASK: Correct if condition for pushing branches

### DIFF
--- a/slicer.php
+++ b/slicer.php
@@ -205,7 +205,7 @@ class Slicer
         $preparedCommand = sprintf(
             "git for-each-ref --format='%%(refname)' %s | " .
             "while read refname ; do " .
-                "if [ -n 'git ls-tree \$refname composer.json' ]; then " .
+                "if [[ \$(git ls-tree \$refname composer.json) ]]; then " .
                     "git push -f %s \$refname ; " .
                 "fi ; " .
             "done",


### PR DESCRIPTION
Only push if the `git ls-tree $refname composer.json` has output meaning there is a composer.json in root of that branch.

The previous if condition didn't correctly work and always ways true-ish due to shell escaping and not executing the git command.

Fixes:  #17