### PR TITLE
BUGFIX: Use clone_url from payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ in the payload, processing of the split is skipped.
 
 ## Manual invocation
 
-Use a payload like `{"ref":"…","repository":{"url":"https://github.com/…"}}`
-and replace `ref` and `url` values as needed:
+Use a payload like `{"ref":"…","repository":{"clone_url":"https://github.com/…"}}`
+and replace `ref` and `clone_url` values as needed:
 
-`php slicer.php '{"ref":"refs/heads/8.2","repository":{"url":"https://github.com/neos/flow-development-collection"}}'`
+`php slicer.php '{"ref":"refs/heads/8.2","repository":{"clone_url":"https://github.com/neos/flow-development-collection.git"}}'`
 
 To split a tag, just use
 
-`php slicer.php '{"ref":"refs/tags/1.2.3","repository":{"url":"https://github.com/…"}}'`
+`php slicer.php '{"ref":"refs/tags/1.2.3","repository":{"clone_url":"https://github.com/…"}}'`

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "working-directory": "split-temporary",
     "projects": {
         "Flow": {
-            "url": "https://github.com/neos/flow-development-collection",
+            "url": "https://github.com/neos/flow-development-collection.git",
             "allowedRefsPattern": "/^refs\\/(?:tags|heads)\\/(?:[0-9]+\\.[0-9]+(?:\\.[0-9]+)?(?:-(?:alpha|beta)(?:[0-9]+))?)$/",
             "splits": {
                 "Neos.Cache": {
@@ -110,7 +110,7 @@
             }
         },
         "Neos": {
-            "url": "https://github.com/neos/neos-development-collection",
+            "url": "https://github.com/neos/neos-development-collection.git",
             "allowedRefsPattern": "/^refs\\/(?:tags|heads)\\/(?:[0-9]+\\.[0-9]+(?:\\.[0-9]+)?(?:-(?:alpha|beta)(?:[0-9]+))?)$/",
             "splits": {
                 "Neos.ContentGraph.DoctrineDbalAdapter": {

--- a/slicer.php
+++ b/slicer.php
@@ -48,13 +48,13 @@ class Slicer
         $projectName = null;
         $projectConfiguration = [];
         foreach ($this->configuration['projects'] as $potentialProjectName => $projectConfiguration) {
-            if ($projectConfiguration['url'] === $parsedPayload['repository']['url']) {
+            if ($projectConfiguration['url'] === $parsedPayload['repository']['clone_url']) {
                 $projectName = $potentialProjectName;
                 break;
             }
         }
         if ($projectName === null || $projectConfiguration === []) {
-            echo sprintf('Skipping request for URL %s (not configured)', $parsedPayload['repository']['url']) . PHP_EOL;
+            echo sprintf('Skipping request for URL %s (not configured)', $parsedPayload['repository']['clone_url']) . PHP_EOL;
             exit(0);
         }
 


### PR DESCRIPTION
The payload has changed and the repository.url is now an API endpoint (https://api.github.com/repos/neos/neos-development-collection). As we actually need the clone_url, we could change it to repository.clone_url.