### PR TITLE
TASK: Deactivate split of `Neos.ContentGraph.PostgreSQLAdapter`

### DIFF
--- a/config.json
+++ b/config.json
@@ -119,12 +119,6 @@
                         "Neos.ContentGraph.DoctrineDbalAdapter"
                     ]
                 },
-                "Neos.ContentGraph.PostgreSQLAdapter": {
-                    "repository": "git@github.com:neos/contentgraph-postgresqladapter.git",
-                    "folders": [
-                        "Neos.ContentGraph.PostgreSQLAdapter"
-                    ]
-                },
                 "Neos.ContentRepository": {
                     "repository": "git@github.com:neos/content-repository.git",
                     "folders": [


### PR DESCRIPTION
This allows us to take https://github.com/neos/contentgraph-postgresqladapter over manually.

Which is the plan to release https://github.com/neos/neos-development-collection/pull/5751 

The new PostgreSQL adapter is still experimental and thus we profit from an independent release cycle.